### PR TITLE
Improve usage tutorial and add detailed quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # font_gan
 
-フォントをGANで生成するための実験リポジトリです。`docs/` 以下に使い方や学習戦略をまとめています。
+フォントを GAN で生成するための実験リポジトリです。`docs/` 以下に学習手順や環境構
+築の詳細をまとめています。ここでは最小構成での実行例を示します。
+
+## 環境セットアップ
+
+1. [環境構築ガイド](docs/installation.md) に従い Conda 環境を作成します。
+2. ライブラリをインストール後、以下のコマンドで GPU が利用可能か確認します。
+
+```bash
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+## 基本的な学習
+
+フォントファイルを `fonts/` に配置したら、次のコマンドで 256px から 512px まで連続
+学習できます。
+
+```bash
+python train_pix2pix_pro.py \
+  --stage s1_256 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf
+
+python train_pix2pix_pro.py \
+  --stage s2_512 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf \
+  --checkpoint_dir ./checkpoints/pro_run
+```
+
+## 推論
+
+学習済みモデルを使って新しいグリフを生成するには次のようにします。
+
+```python
+from train_pix2pix import inference
+chars = {ord("あ"): "あ"}
+inference("checkpoints/pro_run/G_epoch200.pth", chars, "fonts/reference_font.otf", "output")
+```
+
+チュートリアル形式での説明は [docs/tutorial.md](docs/tutorial.md) を参照してくださ
+い。

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 ## ドキュメント構成
 
 - [環境構築ガイド](installation.md)
+- [チュートリアル](tutorial.md)
 - [使用方法の概要](usage.md)
 - [学習手順](usage/training.md)
 - [推論手順](usage/inference.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,4 +92,5 @@ python train_pix2pix.py
 ```
 
 学習後は生成された PNG を FontForge 等でトレースし、フォントファイルへ組み込んでください。
+引き続き [チュートリアル](tutorial.md) で実行例を確認するとスムーズです。
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,53 @@
+# チュートリアル
+
+このチュートリアルでは、環境構築から学習、推論までの基本的な流れをまとめます。
+より詳細なオプションは各ドキュメントを参照してください。
+
+## 1. 環境を整える
+
+1. [環境構築ガイド](installation.md) に従い Conda 環境を作成します。
+2. 必要なライブラリをインストール後、以下のコマンドで GPU が認識されていることを確認します。
+
+```bash
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+`True` が表示されれば準備完了です。
+
+## 2. フォントを配置する
+
+`fonts/` ディレクトリに補完対象のフォント (`target_font.otf`) と参考フォント (`reference_font.otf`) を置きます。
+学習文字リストは `--include_chars` でファイル指定するか、フォント内の非空白グリフを自動抽出できます。
+
+## 3. 学習を実行する
+
+まずは 256px で事前学習を行い、その後 512px へ微調整する例を示します。
+
+```bash
+python train_pix2pix_pro.py \
+  --stage s1_256 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf
+
+python train_pix2pix_pro.py \
+  --stage s2_512 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf \
+  --checkpoint_dir ./checkpoints/pro_run
+```
+
+学習中は `checkpoints/` 以下にモデルやログが保存されます。`tensorboard --logdir` で進捗を確認できます。
+
+## 4. 生成を試す
+
+学習したモデルを使ってグリフを生成するには `inference` 関数を利用します。
+
+```python
+from train_pix2pix import inference
+
+chars = {ord("あ"): "あ"}
+inference("checkpoints/pro_run/G_epoch200.pth", chars, "fonts/reference_font.otf", "output")
+```
+
+`output/` には Unicode 番号をファイル名とした PNG が出力されます。必要に応じて FontForge などでトレースしてフォントへ取り込みます。
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,7 @@
 # 使用方法
 
 このページでは `train_pix2pix.py` を利用した学習と推論の流れをまとめます。
+初めての方は [チュートリアル](tutorial.md) も参照してください。
 
 ## データ準備
 
@@ -35,6 +36,20 @@ stagewise_train(
 まず全文字で事前学習を行い、その後不足文字のみを低学習率で微調整します。`rehearsal_ratio` を指定すると既存文字の一部も混在させて忘却を防止できます。`freeze_layers` でジェネレータ前半を固定し、`perceptual_lambda` により Perceptual Loss の強さを調節します。`augment=True` を指定すると学習時にアフィン変換やノイズ付与が行われます。
 
 より簡単に2段階学習を行う場合は `train_pix2pix_pro.py` を実行してください。
+例えば次のように 256px 事前学習と 512px 微調整を連続実行できます。
+
+```bash
+python train_pix2pix_pro.py \
+  --stage s1_256 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf
+
+python train_pix2pix_pro.py \
+  --stage s2_512 \
+  --ref_font ./fonts/reference_font.otf \
+  --target_font ./fonts/target_font.otf \
+  --checkpoint_dir ./checkpoints/pro_run
+```
 ## 推論
 
 ```python


### PR DESCRIPTION
## Summary
- expand README with quick examples
- add tutorial doc with step-by-step guide
- link tutorial from index and installation docs
- elaborate usage docs with pro script example

## Testing
- `python -m py_compile train_pix2pix.py train_pix2pix_pro.py`

------
https://chatgpt.com/codex/tasks/task_e_6858b0e032f0832fa6004399a101a6d5