### PR TITLE
Add pip+venv setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## 環境セットアップ
 
-1. [環境構築ガイド](docs/installation.md) に従い Conda 環境を作成します。
+1. Conda 版の [環境構築ガイド](docs/installation.md) または、pip を使った [pip + venv での環境構築](docs/installation_venv.md) に従ってセットアップします。
 2. ライブラリをインストール後、以下のコマンドで GPU が利用可能か確認します。
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 ## ドキュメント構成
 
 - [環境構築ガイド](installation.md)
+- [pip + venv での環境構築](installation_venv.md)
 - [チュートリアル](tutorial.md)
 - [使用方法の概要](usage.md)
 - [学習手順](usage/training.md)

--- a/docs/installation_venv.md
+++ b/docs/installation_venv.md
@@ -1,0 +1,95 @@
+# 環境構築ガイド（pip + venv 版）
+
+このドキュメントでは `conda` を利用しない場合のセットアップ手順を説明します。標準の `venv` と `pip` を使って環境を構築する方法です。
+
+## 1. システム要件
+
+- **OS**: Ubuntu 20.04 LTS を推奨。Windows では WSL2 上での利用を想定しています。
+- **GPU**: CUDA 対応の NVIDIA GPU (メモリ 8GB 以上)。
+- **ドライバと CUDA**: `nvidia-smi` で確認できる最新ドライバを導入し、CUDA 11.x もしくは 12.x をインストールしてください。
+- **ディスク容量**: フォント画像やチェックポイントを保存するため数 GB の空き容量が必要です。
+
+## 2. Python と仮想環境の準備
+
+1. Python 3.9 以上をインストールします。
+2. プロジェクト用の仮想環境を作成し、有効化します。
+
+```bash
+python3 -m venv font_gan_venv
+source font_gan_venv/bin/activate
+```
+
+## 3. GPU 動作確認
+
+```bash
+nvidia-smi
+```
+
+CUDA バージョンや GPU が表示されれば準備完了です。
+
+## 4. PyTorch のインストール
+
+自身の CUDA バージョンに合わせて PyTorch をインストールします。以下は CUDA 11.8 を使用する例です。
+
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+```
+
+インストール後、以下のスクリプトで GPU が利用可能か確認できます。
+
+```python
+import torch
+print(torch.__version__, torch.cuda.is_available())
+```
+
+## 5. 追加ライブラリ
+
+画像処理や評価指標、TensorBoard などのライブラリをインストールします。
+
+```bash
+pip install Pillow scipy opencv-python
+pip install scikit-image
+pip install tensorboard
+# Optional
+pip install optuna
+pip install fontforge
+```
+
+## 6. ディレクトリ構造
+
+学習用フォルダは以下のように配置します。`checkpoints/` や `output/` はスクリプト実行時に自動生成されます。
+
+```
+font_gan/
+├── train_pix2pix.py
+├── checkpoints/
+├── data/
+│   ├── train_s1/{source,target}/
+│   └── train_s2/{source,target}/
+├── output/
+└── fonts/
+    ├── GD-HighwayGothicJA.otf
+    └── reference_font.otf
+```
+
+## 7. TensorBoard の起動
+
+学習中のログは次のコマンドで確認できます。
+
+```bash
+tensorboard --logdir ./checkpoints/gd_highway_pro/logs
+```
+
+ブラウザで `http://localhost:6006/` を開くと損失やサンプル画像を閲覧できます。
+
+## 8. 学習と推論
+
+仮想環境を有効化し、`train_pix2pix.py` を実行すると学習が始まります。Stage1(256px) から Stage2(512px) へ自動で移行し、生成結果は `output/` に保存されます。
+
+```bash
+source font_gan_venv/bin/activate
+python train_pix2pix.py
+```
+
+学習後は生成された PNG を FontForge 等でトレースし、フォントファイルへ組み込んでください。
+チュートリアルは [tutorial.md](tutorial.md) を参照してください。


### PR DESCRIPTION
## Summary
- document how to set up with pip and `venv`
- link new manual from README and docs index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859bf130be4832fba12aa17f7ef2f8e