### PR TITLE
Add Windows setup docs and helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 
 ## 環境セットアップ
 
-1. Conda 版の [環境構築ガイド](docs/installation.md) または、pip を使った [pip + venv での環境構築](docs/installation_venv.md) に従ってセットアップします。
+1. Conda 版の [環境構築ガイド](docs/installation.md) または、pip を使った [pip + venv での環境構築](docs/installation_venv.md) に従ってセットアップします。 Windows ユーザーは [Windows 版セットアップ](docs/installation_windows.md) も参照してください。
 2. ライブラリをインストール後、以下のコマンドで GPU が利用可能か確認します。
 
 ```bash
 python -c "import torch; print(torch.cuda.is_available())"
+また、このコマンドを `scripts/check_gpu.py` として保存したファイルも用意してあります。
 ```
 
 ## 基本的な学習

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@
 
 - [環境構築ガイド](installation.md)
 - [pip + venv での環境構築](installation_venv.md)
+- [Windows 版セットアップ](installation_windows.md)
 - [チュートリアル](tutorial.md)
 - [使用方法の概要](usage.md)
 - [学習手順](usage/training.md)

--- a/docs/installation_venv.md
+++ b/docs/installation_venv.md
@@ -2,6 +2,7 @@
 
 このドキュメントでは `conda` を利用しない場合のセットアップ手順を説明します。標準の `venv` と `pip` を使って環境を構築する方法です。
 
+また、Windows 環境向けの手順は [installation_windows.md](installation_windows.md) を参照してください。
 ## 1. システム要件
 
 - **OS**: Ubuntu 20.04 LTS を推奨。Windows では WSL2 上での利用を想定しています。
@@ -18,6 +19,7 @@
 python3 -m venv font_gan_venv
 source font_gan_venv/bin/activate
 ```
+これらの手順は `scripts/setup.sh` を実行することで自動化できます。
 
 ## 3. GPU 動作確認
 
@@ -25,6 +27,7 @@ source font_gan_venv/bin/activate
 nvidia-smi
 ```
 
+`nvidia-smi: command not found` と表示される場合は GPU ドライバがインストールされていません。CPU で実行するか、NVIDIA 公式サイトからドライバを入れてください。
 CUDA バージョンや GPU が表示されれば準備完了です。
 
 ## 4. PyTorch のインストール
@@ -41,6 +44,7 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 import torch
 print(torch.__version__, torch.cuda.is_available())
 ```
+上記コードを `scripts/check_gpu.py` として保存して実行できます。
 
 ## 5. 追加ライブラリ
 
@@ -71,8 +75,11 @@ font_gan/
     ├── GD-HighwayGothicJA.otf
     └── reference_font.otf
 ```
+## 7. 初回準備ファイル
 
-## 7. TensorBoard の起動
+最初に `fonts/` ディレクトリに補完対象フォントと参考フォントを配置します。既存画像を利用する場合は `data/train_s1` や `data/train_s2` 以下に PNG を置きます。必要に応じて `config.json` や学習文字リストもここに準備してください。
+
+## 8. TensorBoard の起動
 
 学習中のログは次のコマンドで確認できます。
 
@@ -82,7 +89,7 @@ tensorboard --logdir ./checkpoints/gd_highway_pro/logs
 
 ブラウザで `http://localhost:6006/` を開くと損失やサンプル画像を閲覧できます。
 
-## 8. 学習と推論
+## 9. 学習と推論
 
 仮想環境を有効化し、`train_pix2pix.py` を実行すると学習が始まります。Stage1(256px) から Stage2(512px) へ自動で移行し、生成結果は `output/` に保存されます。
 

--- a/docs/installation_windows.md
+++ b/docs/installation_windows.md
@@ -1,0 +1,36 @@
+# Windows 版セットアップガイド
+
+このドキュメントでは Windows 環境で `pip` と `venv` を用いて本プロジェクトを動作させる方法を説明します。WSL2 ではなく、純粋な Windows 上に Python がインストールされていることを想定しています。
+
+## 1. 必要なソフトウェア
+
+- Python 3.9 以上
+- NVIDIA GPU と最新ドライバ (CUDA 11.x または 12.x 対応)
+- Git (オプション)
+
+## 2. 仮想環境の作成とライブラリのインストール
+
+同梱の `scripts/setup_windows.bat` を実行すると、仮想環境の作成から主要ライブラリのインストールまで自動で行われます。PowerShell から次のように実行してください。
+
+```powershell
+cd path\to\font_gan
+./scripts/setup_windows.bat
+```
+
+上記では CUDA 11.8 用の PyTorch を導入しています。CUDA バージョンが異なる場合はスクリプト内の URL を適宜変更してください。
+
+## 3. GPU の確認
+
+ドライバが正しくインストールされていれば、`nvidia-smi` コマンドで GPU の情報が表示されます。`'nvidia-smi' is not recognized` と表示された場合はドライバが不足しています。NVIDIA 公式サイトから Windows 用ドライバをインストールしてください。
+
+環境が整ったら、以下のスクリプトで PyTorch が GPU を認識するかを確認します。
+
+```bash
+python scripts/check_gpu.py
+```
+
+`True` が表示されれば GPU が利用可能です。`False` のときは CUDA のパスやドライバの設定を見直してください。
+
+## 4. ディレクトリ構造と初回準備
+
+基本的なフォルダ構成は Linux 版と共通です。`fonts/` に補完対象フォント (`GD-HighwayGothicJA.otf` など) と参考フォントを配置し、`data/` 以下に学習用画像を用意します。詳しくは [installation_venv.md](installation_venv.md) の "初回準備ファイル" を参照してください。

--- a/scripts/check_gpu.py
+++ b/scripts/check_gpu.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""check_gpu.py — check_gpu
+
+概要:
+    PyTorch が GPU を利用可能かを確認する簡単なスクリプト。
+
+:author: pumpCurry
+:copyright: (c) pumpCurry 2025 / 5r4ce2
+:license: MIT
+:version: 1.0.58 (PR #26)
+:since:   1.0.58 (PR #26)
+:last-modified: 2025-06-23 12:00:00 JST+9
+:todo:
+    - None
+"""
+
+import torch
+
+
+def main() -> None:
+    """GPU 利用可否を表示する。"""
+    print(torch.__version__, torch.cuda.is_available())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# setup.sh - Create virtual environment and install packages on Linux/WSL
+
+python3 -m venv font_gan_venv
+source font_gan_venv/bin/activate
+pip install --upgrade pip
+# Install PyTorch for CUDA 11.8
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+# Additional libraries
+pip install Pillow scipy opencv-python scikit-image tensorboard
+# Optional packages
+pip install optuna fontforge
+
+echo "Environment setup complete."
+

--- a/scripts/setup_windows.bat
+++ b/scripts/setup_windows.bat
@@ -1,0 +1,15 @@
+@echo off
+REM setup_windows.bat - Create virtual environment and install requirements
+
+python -m venv font_gan_venv
+call font_gan_venv\Scripts\activate
+python -m pip install --upgrade pip
+REM Install PyTorch (CUDA 11.8 example)
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+REM Additional libraries
+pip install Pillow scipy opencv-python scikit-image tensorboard
+REM Optional packages
+pip install optuna fontforge
+
+echo Environment setup complete.
+


### PR DESCRIPTION
## Summary
- add Windows installation guide
- update pip+venv instructions with Windows notes and initial setup section
- reference new docs in README and index
- add scripts to setup environments and check GPU

## Testing
- `python -m py_compile scripts/check_gpu.py`


------
https://chatgpt.com/codex/tasks/task_e_685a22ac710c832f9c9733f6f9aa306b