### PR TITLE
Add startup prints and help support

### DIFF
--- a/scripts/check_gpu.py
+++ b/scripts/check_gpu.py
@@ -7,18 +7,23 @@
 :author: pumpCurry
 :copyright: (c) pumpCurry 2025 / 5r4ce2
 :license: MIT
-:version: 1.0.58 (PR #26)
+:version: 1.0.80 (PR #38)
 :since:   1.0.58 (PR #26)
-:last-modified: 2025-06-23 12:00:00 JST+9
+:last-modified: 2025-07-13 22:57:24 JST+9
 :todo:
     - None
 """
 
+import argparse
+import os
 import torch
 
 
 def main() -> None:
     """GPU 利用可否を表示する。"""
+    parser = argparse.ArgumentParser(description="Check GPU availability")
+    parser.parse_args()
+    print(f"{os.path.basename(__file__)} launched.")
     print(torch.__version__, torch.cuda.is_available())
 
 

--- a/train_pix2pix.py
+++ b/train_pix2pix.py
@@ -7,9 +7,9 @@
 :author: pumpCurry
 :copyright: (c) pumpCurry 2025 / 5r4ce2
 :license: MIT
-:version: 1.0.54 (PR #24)
+:version: 1.0.80 (PR #38)
 :since:   1.0.15 (PR #7)
-:last-modified: 2025-06-23 05:00:00 JST+9
+:last-modified: 2025-07-13 22:57:24 JST+9
 
 :todo:
     - Refactor training loop for CLI usage
@@ -19,6 +19,7 @@ import io
 import os
 import glob
 import random
+import argparse
 from typing import Callable, Tuple, Dict
 
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
@@ -765,7 +766,8 @@ def train_from_config(config_path: str) -> None:
     train(**cfg)
 
 
-if __name__ == "__main__":
+def _run_example() -> None:
+    """Execute default example training pipeline."""
     TARGET_FONT_PATH = "path/to/GD-HighwayGothicJA.otf"
     REFERENCE_FONT_PATH = "path/to/reference_font.otf"
     OUTPUT_DIR_TRAIN = "data_updated"
@@ -776,19 +778,14 @@ if __name__ == "__main__":
     LEARNING_RATE = 0.0002
     L1_LAMBDA = 100
 
-    common_chars_for_training = {
-        ord("あ"): "あ",
-        ord("い"): "い",
-    }
+    common_chars_for_training = {ord("あ"): "あ", ord("い"): "い"}
 
     if not common_chars_for_training:
         raise ValueError("Training characters not specified")
     if not os.path.exists(TARGET_FONT_PATH) or not os.path.exists(REFERENCE_FONT_PATH):
         raise FileNotFoundError("Font file not found")
 
-    missing_chars_to_generate = {
-        ord("琉"): "琉",
-    }
+    missing_chars_to_generate = {ord("琉"): "琉"}
 
     stagewise_train(
         target_font_path=TARGET_FONT_PATH,
@@ -821,4 +818,20 @@ if __name__ == "__main__":
             out_dir=GENERATED_FONT_DIR,
             batch_size=BATCH_SIZE,
         )
+
+
+def main() -> None:
+    """Entry point for command line execution."""
+    parser = argparse.ArgumentParser(description="Train pix2pix font model")
+    parser.add_argument("--config", type=str, default=None, help="YAML config file")
+    args = parser.parse_args()
+    print(f"{os.path.basename(__file__)} launched.")
+    if args.config:
+        train_from_config(args.config)
+    else:
+        _run_example()
+
+
+if __name__ == "__main__":
+    main()
 

--- a/train_pix2pix_pro.py
+++ b/train_pix2pix_pro.py
@@ -7,9 +7,9 @@
 :author: pumpCurry
 :copyright: (c) pumpCurry 2025 / 5r4ce2
 :license: MIT
-:version: 1.0.78 (PR #37)
+:version: 1.0.80 (PR #38)
 :since:   1.0.30 (PR #14)
-:last-modified: 2025-07-13 20:17:12 JST+9
+:last-modified: 2025-07-13 22:57:24 JST+9
 :todo:
     - Improve configurability via YAML
 """
@@ -1063,6 +1063,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+    print(f"{os.path.basename(__file__)} launched.")
 
     candidate_chars = build_candidate_chars(
         include_file=args.include_chars or args.candidate_char_file,


### PR DESCRIPTION
## Summary
- add `--config` CLI and startup print to `train_pix2pix.py`
- print startup message in `train_pix2pix_pro.py`
- convert `scripts/check_gpu.py` to argparse based CLI
- bump versions and timestamps

## Testing
- `python -m py_compile train_pix2pix.py train_pix2pix_pro.py scripts/check_gpu.py`

------
https://chatgpt.com/codex/tasks/task_e_6873bac25b90832f9e0e68dff691709e